### PR TITLE
Bench 251 - Add Prettier plugin for TailwindCSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite App</title>
   </head>
-  <body class="bg-gradient-to-br from-[#333F4C] to-[#000000] text-white font-roboto m-0 bg-no-repeat bg-fixed">
+  <body class="font-roboto m-0 bg-gradient-to-br from-[#333F4C] to-[#000000] bg-fixed bg-no-repeat text-white">
     <div id="root" class="h-screen"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "autoprefixer": "^10.4.13",
         "classnames": "^2.3.2",
         "eslint-plugin-cypress": "^2.12.1",
-        "postcss-cli": "^10.0.0",
+        "postcss-cli": "^10.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-helmet-async": "^1.3.0",
@@ -33,7 +33,7 @@
         "@typescript-eslint/parser": "^5.45.0",
         "@vitejs/plugin-react": "^2.1.0",
         "cypress": "^11.2.0",
-        "eslint": "^8.28.0",
+        "eslint": "^8.29.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-jsx-a11y": "^6.6.1",
@@ -43,6 +43,7 @@
         "jest": "^29.2.2",
         "jest-environment-jsdom": "^29.2.2",
         "prettier": "^2.8.0",
+        "prettier-plugin-tailwindcss": "^0.2.0",
         "sass": "^1.55.0",
         "ts-jest": "^29.0.3",
         "ts-node": "^10.9.1",
@@ -4130,7 +4131,6 @@
       "version": "8.29.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.29.0.tgz",
       "integrity": "sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==",
-      "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.3.3",
         "@humanwhocodes/config-array": "^0.11.6",
@@ -8051,6 +8051,18 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.2.0.tgz",
+      "integrity": "sha512-Ruqig/mdWCSpqdq9WK44nrmqM4BFWTzBPhPGwC5NK3coV9eZntEQPB84MGZbjAg0XQU02jVRHXNRPREBzxvM+A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.17.0"
+      },
+      "peerDependencies": {
+        "prettier": ">=2.2.0"
       }
     },
     "node_modules/pretty-bytes": {
@@ -12735,7 +12747,6 @@
       "version": "8.29.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.29.0.tgz",
       "integrity": "sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==",
-      "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.3.3",
         "@humanwhocodes/config-array": "^0.11.6",
@@ -15566,6 +15577,13 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
       "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
       "dev": true
+    },
+    "prettier-plugin-tailwindcss": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.2.0.tgz",
+      "integrity": "sha512-Ruqig/mdWCSpqdq9WK44nrmqM4BFWTzBPhPGwC5NK3coV9eZntEQPB84MGZbjAg0XQU02jVRHXNRPREBzxvM+A==",
+      "dev": true,
+      "requires": {}
     },
     "pretty-bytes": {
       "version": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "jest": "^29.2.2",
     "jest-environment-jsdom": "^29.2.2",
     "prettier": "^2.8.0",
+    "prettier-plugin-tailwindcss": "^0.2.0",
     "sass": "^1.55.0",
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -20,9 +20,9 @@ export const Button = ({
 }: Props): ReactElement => {
   return (
     <button
-      className={cn('bg-[#FFC600] border-solid border-[#FFC600] border-2 transition duration-500 hover:cursor-pointer', className, {
-        'text-[12px] py-1 px-2 rounded-md text-white': size === 'small',
-        'text-[20px] py-2.5 px-12 rounded-full text-[#333F4C] hover:bg-[#333F4C] hover:border-[#333F4C] hover:text-white font-bold': size === 'large',
+      className={cn('border-2 border-solid border-[#FFC600] bg-[#FFC600] transition duration-500 hover:cursor-pointer', className, {
+        'rounded-md py-1 px-2 text-[12px] text-white': size === 'small',
+        'rounded-full py-2.5 px-12 text-[20px] font-bold text-[#333F4C] hover:border-[#333F4C] hover:bg-[#333F4C] hover:text-white': size === 'large',
         'cursor-pointer bg-[#5A6675]': active,
       })}
       data-testid={dataTestId}

--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -5,5 +5,5 @@ interface Props {
 }
 
 export const Container = ({ children }: Props): ReactElement => {
-  return <div className="self-center box-border">{children}</div>;
+  return <div className="box-border self-center">{children}</div>;
 };

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -4,12 +4,12 @@ import AnswerLogo from 'assets/logo.png';
 export const Navigation = (): ReactElement => {
   return (
     <nav className="bg-[#5A6675] p-5">
-      <div className="container flex flex-wrap items-center justify-between mx-auto">
+      <div className="container mx-auto flex flex-wrap items-center justify-between">
         <a href="/" className="ml-16">
           <img src={AnswerLogo} className="h-[60.18px] w-[170px]"></img>
         </a>
-        <div className="md:order-2 mr-16">
-          <button className="bg-[#A2AAB6] py-[8px] px-[40px] rounded-[25px] text-black hover:cursor-pointer">Log in</button>
+        <div className="mr-16 md:order-2">
+          <button className="rounded-[25px] bg-[#A2AAB6] py-[8px] px-[40px] text-black hover:cursor-pointer">Log in</button>
         </div>
       </div>
     </nav>

--- a/src/components/OrderLoadForm/__snapshots__/OrderLoadForm.test.tsx.snap
+++ b/src/components/OrderLoadForm/__snapshots__/OrderLoadForm.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`OrderLoadForm component should match the snapshot 1`] = `
       value="1"
     />
     <button
-      class="bg-[#FFC600] border-solid border-[#FFC600] border-2 transition duration-500 hover:cursor-pointer order_load_form__button"
+      class="border-2 border-solid border-[#FFC600] bg-[#FFC600] transition duration-500 hover:cursor-pointer order_load_form__button"
       data-testid="order-load-submit-button"
       type="submit"
     >

--- a/src/components/ProductsTable/ProductsTable.tsx
+++ b/src/components/ProductsTable/ProductsTable.tsx
@@ -12,9 +12,9 @@ export const ProductsTable = (): ReactElement => {
         <tr>
           <th className="text-left">ID</th>
           <th className="text-left">Name</th>
-          <th className="text-right products_table__hide_mobile">Price</th>
-          <th className="text-left products_table__hide_mobile">Description</th>
-          <th className="text-left products_table__hide_mobile">Categories</th>
+          <th className="products_table__hide_mobile text-right">Price</th>
+          <th className="products_table__hide_mobile text-left">Description</th>
+          <th className="products_table__hide_mobile text-left">Categories</th>
           <th />
         </tr>
       </thead>

--- a/src/components/ProductsTableRow/ProductsTableRow.tsx
+++ b/src/components/ProductsTableRow/ProductsTableRow.tsx
@@ -23,8 +23,8 @@ export const ProductsTableRow = ({ product }: Props): ReactElement => {
     <tr>
       <td className="text-left">{product.id}</td>
       <td className="text-left">{product.name}</td>
-      <td className="text-right products_table__hide_mobile">£{product.price.toFixed(2)}</td>
-      <td className="text-left products_table__hide_mobile">{product.description}</td>
+      <td className="products_table__hide_mobile text-right">£{product.price.toFixed(2)}</td>
+      <td className="products_table__hide_mobile text-left">{product.description}</td>
       {/*<td className="text-left products_table__hide_mobile">*/}
       {/*  {product.categories?.map((category) => category.name).join(', ')}*/}
       {/*</td>*/}

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -18,8 +18,8 @@ export const HomePage = (): ReactElement => {
         <title>Home - Answer King</title>
       </Helmet>
       <div className="grid grid-cols-2 gap-2">
-        <div className="flex flex-col justify-center items-center ml-44 mt-20">
-          <div className="text-white text-[80px] text-center mb-10">
+        <div className="ml-44 mt-20 flex flex-col items-center justify-center">
+          <div className="mb-10 text-center text-[80px] text-white">
             <h3 className="font-poly leading-tight">
               The Answer to <br></br> your cravings
             </h3>


### PR DESCRIPTION
Installed prettier plugin for tailwind, now the 'format' script should automatically sort the class names of tailwind components to be more readable. Overview of module [here](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier)