### PR TITLE
BENCH-440: Fix checkboxes not registering values in RHF

### DIFF
--- a/src/components/Inputs/Checkbox.tsx
+++ b/src/components/Inputs/Checkbox.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useState } from 'react';
+import React, { forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react';
 import cn from 'classnames';
 import { CheckBoxIcon } from 'components/Icons/CheckBoxIcon';
 
@@ -7,11 +7,26 @@ interface Props extends React.ComponentPropsWithRef<'input'> {
 }
 
 export const Checkbox = forwardRef<HTMLInputElement, Props>(({ label, className, id, ...rest }, ref) => {
+  const innerRef = useRef<HTMLInputElement>(null);
   const [checked, setChecked] = useState<boolean>(false);
 
+  useImperativeHandle(ref, () => innerRef.current as HTMLInputElement);
+
+  const handleChecked = useCallback(
+    (value: boolean) => {
+      const checkbox = innerRef.current;
+
+      if (checkbox) {
+        setChecked(value);
+        checkbox.click();
+      }
+    },
+    [innerRef]
+  );
+
   return (
-    <div className={cn('flex w-fit cursor-pointer select-none items-center gap-2', className)} onClick={() => setChecked(!checked)}>
-      <input className="hidden" type="checkbox" checked={checked} id={id} ref={ref} {...rest}></input>
+    <div className={cn('flex w-fit cursor-pointer select-none items-center gap-2', className)} onClick={() => handleChecked(!checked)}>
+      <input className="hidden" type="checkbox" id={id} ref={innerRef} {...rest}></input>
       <CheckBoxIcon checked={checked} />
       <span>{label}</span>
     </div>

--- a/src/components/Inputs/Checkbox.tsx
+++ b/src/components/Inputs/Checkbox.tsx
@@ -6,9 +6,9 @@ interface Props extends React.ComponentPropsWithRef<'input'> {
   label?: string;
 }
 
-export const Checkbox = forwardRef<HTMLInputElement, Props>(({ label, className, id, ...rest }, ref) => {
+export const Checkbox = forwardRef<HTMLInputElement, Props>(({ label, className, checked, defaultChecked, id, ...rest }, ref) => {
   const innerRef = useRef<HTMLInputElement>(null);
-  const [checked, setChecked] = useState<boolean>(false);
+  const [isChecked, setIsChecked] = useState<boolean>(checked ?? defaultChecked ?? false);
 
   useImperativeHandle(ref, () => innerRef.current as HTMLInputElement);
 
@@ -17,7 +17,7 @@ export const Checkbox = forwardRef<HTMLInputElement, Props>(({ label, className,
       const checkbox = innerRef.current;
 
       if (checkbox) {
-        setChecked(value);
+        setIsChecked(value);
         checkbox.click();
       }
     },
@@ -25,9 +25,9 @@ export const Checkbox = forwardRef<HTMLInputElement, Props>(({ label, className,
   );
 
   return (
-    <div className={cn('flex w-fit cursor-pointer select-none items-center gap-2', className)} onClick={() => handleChecked(!checked)}>
+    <div className={cn('flex w-fit cursor-pointer select-none items-center gap-2', className)} onClick={() => handleChecked(!isChecked)}>
       <input className="hidden" type="checkbox" id={id} ref={innerRef} {...rest}></input>
-      <CheckBoxIcon checked={checked} />
+      <CheckBoxIcon checked={isChecked} />
       <span>{label}</span>
     </div>
   );


### PR DESCRIPTION
`react-hook-forms` uses `onChange` events to track values of elements in the form state. These are automatically implemented when we call `register` on the element. When I set the `checked` value of the hidden input to the `checked` state value, the `onChange` event would not get triggered, and the value wouldn't be reflected in the form state. 

We go around this issue by getting the ref of the hidden input and forcibly call `.click` on it whenever we click the checkbox SVG. This now triggers the `onChange` event.
