### PR TITLE
BENCH-446: Fix dependabot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,8 +69,8 @@
         "vite": "^4.0.1"
       },
       "engines": {
-        "node": "^18.14 || ^16",
-        "npm": "^9 || ^8"
+        "node": "^18.14",
+        "npm": "^9"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,8 +69,8 @@
         "vite": "^4.0.1"
       },
       "engines": {
-        "node": "^18.14",
-        "npm": "^9"
+        "node": "^18.14 || ^16",
+        "npm": "^9 || ^8"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -80,8 +80,8 @@
     "vite": "^4.0.1"
   },
   "engines": {
-    "node": "^18.14",
-    "npm": "^9"
+    "node": "^18.14 || ^16",
+    "npm": "^9 || ^8"
   },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx}": "npm run formatPretty",


### PR DESCRIPTION
https://github.com/answerdigital/AnswerKing-React/network/updates/614296880

Dependabot uses node 16 + npm 8 whilst we enforce node 18 + npm 9. This updates the package.json to include both versions so that dependabot could do its job again